### PR TITLE
Remove pro from packages

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -25,9 +25,6 @@ module.exports = function(defaults) {
           'faSync'
         ],
         'fontawesome-free-regular': 'all',
-        'fontawesome-pro-light': [
-          'faAdjust'
-        ]
       }
     }
   })

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "@fortawesome/fontawesome-free-regular": "^5.1.0-3",
     "@fortawesome/fontawesome-free-solid": "^5.1.0-3",
-    "@fortawesome/fontawesome-pro-light": "^5.1.0-3",
     "broccoli-asset-rev": "^2.4.5",
     "broccoli-source": "^1.1.0",
     "broccoli-viz": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,12 +26,6 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.1.2-1"
 
-"@fortawesome/fontawesome-pro-light@^5.1.0-3":
-  version "5.1.0-3"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-pro-light/-/fontawesome-pro-light-5.1.0-3.tgz#eef253540988547ac1d85c0b36cdde6e4aba15f9"
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.1.2-1"
-
 "@fortawesome/fontawesome@>=1.2.0-5":
   version "1.2.0-5"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome/-/fontawesome-1.2.0-5.tgz#1e3fcffb80eab9e49f83268dc11289f97bf3fdff"


### PR DESCRIPTION
Otherwise you need a pro license to work on this codebase and even if
you have that your access token is going to end up in the yarn.lock
file.

I don't see any way around this, which is unfortunate for testing.

Unless you want to supply a `.npmrc` file with a token you're willing to use for this project?