### PR TITLE
Find the app when installed in an addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,6 +123,13 @@ module.exports = {
   },
   included(app) {
     this._super.included.apply(this, arguments)
+
+    if (typeof app.import !== 'function' && app.app) {
+      app = app.app
+    }
+
+    this.app = app
+
     this.fontawesomeConfig = this.buildConfig()
     app.import('vendor/fontawesome.js')
     Object.keys(this.fontawesomeConfig.icons).forEach(pack => {


### PR DESCRIPTION
When used in a nested addon this finds the root app and uses it.

see https://github.com/ember-cli/ember-cli/issues/3718

Fixes #18