### PR TITLE
Do a better job of discovering the app we belong to

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,9 +124,12 @@ module.exports = {
   included(app) {
     this._super.included.apply(this, arguments)
 
-    if (typeof app.import !== 'function' && app.app) {
-      app = app.app
-    }
+    let current = this;
+    // Keep iterating upward until we don't have a grandparent.
+    // Has to do this grandparent check because at some point we hit the project.
+    do {
+      app = current.app || app;
+    } while (current.parent.parent && (current = current.parent));
 
     this.app = app
 


### PR DESCRIPTION
When the addon is used in a deeply nested way, this is a much better
strategy to find the top level app. Implementation stolen from
https://github.com/billybonks/ember-cli-stylelint/blob/master/index.js