### PR TITLE
Test with Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 ---
 language: node_js
 node_js:
-  # we recommend testing addons with the same minimum supported node version as Ember CLI
-  # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: false
 dist: trusty


### PR DESCRIPTION
This is the minimum version of some of our dependencies plus node 4 is
EOL in a few weeks.

Tests aren't actually passing, this just exposes the issue in #24.