### PR TITLE
Import the styles needed for svgs

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ var FontAwesomePack = require('./vendor/broccoli-fontawesome-pack')
 var FontAwesomeAutoLibrary = require('./vendor/broccoli-fontawesome-auto-library')
 var glob = require('glob')
 var buildAstTransform = require('./lib/ast-transform');
+var writeFile = require('broccoli-file-creator');
+const { config, dom } = require('@fortawesome/fontawesome-svg-core');
 
 module.exports = {
   name: '@fortawesome/ember-fontawesome',
@@ -70,12 +72,15 @@ module.exports = {
       output: 'autoLibrary.js'
     })
 
+    const fontawesomeStyles = writeFile('fontawesome.css', dom.css());
+
     return new MergeTrees([
       vendorTree,
       fontawesomeRollup,
       autoLibraryNode,
-      ...iconRollups
-    ])
+      ...iconRollups,
+      fontawesomeStyles
+    ]);
   },
 
   buildConfig() {
@@ -147,6 +152,9 @@ module.exports = {
       app.import(`vendor/${pack}.js`)
     })
     app.import('vendor/autoLibrary.js')
+
+    config.autoAddCss = false;
+    app.import('vendor/fontawesome.css');
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.0-10",
+    "broccoli-file-creator": "^1.1.1",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-plugin": "^1.3.0",


### PR DESCRIPTION
Instead of relying on these to be inserted into the DOM which doesn't
work for fastboot or static icons they are included in vendor.css.

Fixes #30