### PR TITLE
Deprecate using an icon object

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,30 +150,6 @@ Without a prefix specified, the default `fas` is assumed:
 {{fa-icon 'square' prefix='far'}}
 ```
 
-### Icon objects
-
-You can also import the icon objects from the icon packs and make them
-available to your templates.
-
-```js
-import Controller from '@ember/controller'
-import { faCoffee } from '@fortawesome/free-solid-svg-icons'
-
-export default Controller.extend({
-  faCoffee,
-  // ...
-});
-```
-
-Then in a template:
-
-```hbs
-{{fa-icon faCoffee}}
-```
-
-This object knows its own prefix, by the way, so it wouldn't be necessary to
-use `prefix=` for disambiguation.
-
 ## Features
 
 The following features are available as [part of Font Awesome](https://fontawesome.com/how-to-use/svg-with-js).
@@ -238,7 +214,7 @@ Power Transforms:
 Masking:
 
 ```hbs
-{{fa-icon 'coffee' transform='shrink-6' mask=faCircle}}
+{{fa-icon 'coffee' transform='shrink-6' mask='circle'}}
 ```
 
 Symbols:

--- a/addon/components/fa-icon.js
+++ b/addon/components/fa-icon.js
@@ -4,6 +4,7 @@ import Ember from 'ember'
 import { icon, parse, toHtml, config } from '@fortawesome/fontawesome-svg-core'
 import { htmlSafe } from '@ember/string'
 import { computed } from '@ember/object'
+import { deprecate } from '@ember/application/deprecations';
 
 function objectWithKey (key, value) {
   return ((Array.isArray(value) && value.length > 0) || (!Array.isArray(value) && value)) ? {[key]: value} : {}
@@ -35,6 +36,14 @@ function normalizeIconArgs (prefix, icon) {
   }
 
   if (typeof icon === 'object' && icon.prefix && icon.iconName) {
+    deprecate(
+      `Passing an icon object is no longer supported, use the icon name as a string instead ({{fa-icon '${icon.iconName}'}}). `,
+      false,
+      {
+        id: 'ember-fontawesome-no-object',
+        until: '0.2.0'
+      }
+    );
     return icon
   }
 

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,9 +1,6 @@
 import Controller from '@ember/controller'
-import { faCoffee, faSquare } from '@fortawesome/free-solid-svg-icons'
 
 export default Controller.extend({
-  faCoffee,
-  faSquare,
   init() {
     this._super(...arguments)
     this.set('magic', 0)

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,10 +1,9 @@
 <h3>Basic Usage</h3>
 {{fa-icon 'coffee'}} (with icon name, after adding icon object to the library)<br/>
-{{fa-icon faCoffee}} (with the icon object explicitly, regardless of library)<br/>
 {{fa-icon icon='coffee' class='foo'}} (explictly using icon attribute, and with additional class name)
 <h3>Mask with Transform</h3>
 <p>(expected: black square with white dot inside, pushed to the right side)</p>
-{{fa-icon icon='circle' transform="shrink-9 right-4" mask=faSquare}}
+{{fa-icon icon='circle' transform="shrink-9 right-4" mask='square'}}
 <h3>Default fas prefix versus specifying a different prefix for the same icon name</h3>
 {{fa-icon icon='square'}}
 {{fa-icon prefix='far' icon='square'}}


### PR DESCRIPTION
Remove documentation and add a deprecation warning for using an icon
object directly.

Fixes #32 

Not really sure if we actually need to do a deprecation dance, but I didn't see any harm.