### PR TITLE
Specify icon names without the fa prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ If you want to include only a subset of icons from an icon pack, add a
 `fontawesome` configuration object to your applications options in
 `ember-cli-build.js`. The following example declares that all icons in
 `free-solid-svg-icons` should be included in the `vendor.js` bundle add
-added to the library, and for `pro-light-svg-icons`, only `adjust` and
-`ambulance` are to be included in the bundle and added to the library.
+added to the library, and for `pro-light-svg-icons`, only `adjust`,
+`ambulance`, and `pencil-alt` are to be included in the bundle and added to the library.
 
 ```
 // ...
@@ -122,7 +122,8 @@ let app = new EmberApp(defaults, {
       'free-solid-svg-icons': 'all'
       'pro-light-svg-icons': [
         'adjust',
-        'ambulance'
+        'ambulance',
+        'pencil-alt'
        ]
     }
 })

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ If you want to include only a subset of icons from an icon pack, add a
 `fontawesome` configuration object to your applications options in
 `ember-cli-build.js`. The following example declares that all icons in
 `free-solid-svg-icons` should be included in the `vendor.js` bundle add
-added to the library, and for `pro-light-svg-icons`, only `faAdjust` and
-`faAmbulance` are to be included in the bundle and added to the library.
+added to the library, and for `pro-light-svg-icons`, only `adjust` and
+`ambulance` are to be included in the bundle and added to the library.
 
 ```
 // ...
@@ -121,8 +121,8 @@ let app = new EmberApp(defaults, {
     icons: {
       'free-solid-svg-icons': 'all'
       'pro-light-svg-icons': [
-        'faAdjust',
-        'faAmbulance'
+        'adjust',
+        'ambulance'
        ]
     }
 })

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -17,10 +17,11 @@ module.exports = function(defaults) {
           'home',
           'info',
           'book',
-          'pencilAlt',
+          'pencil-alt',
           'cog',
           'spinner',
           'checkSquare',
+          'fax',
           'sync'
         ],
         'free-regular-svg-icons': 'all',

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,18 +10,18 @@ module.exports = function(defaults) {
       enableExperimentalBuildTimeTransform: true,
       icons: {
         'free-solid-svg-icons': [
-          'faCoffee',
-          'faMagic',
-          'faCircle',
-          'faSquare',
-          'faHome',
-          'faInfo',
-          'faBook',
-          'faPencilAlt',
-          'faCog',
-          'faSpinner',
-          'faCheckSquare',
-          'faSync'
+          'coffee',
+          'magic',
+          'circle',
+          'square',
+          'home',
+          'info',
+          'book',
+          'pencilAlt',
+          'cog',
+          'spinner',
+          'checkSquare',
+          'sync'
         ],
         'free-regular-svg-icons': 'all',
       }

--- a/index.js
+++ b/index.js
@@ -122,8 +122,8 @@ module.exports = {
         '    icons: {\n'+
         "      'free-solid-svg-icons': 'all'\n"+
         "      'pro-light-svg-icons': [\n"+
-        "        'faAdjust',\n"+
-        "        'faAmbulance'\n"+
+        "        'adjust',\n"+
+        "        'ambulance'\n"+
         '       ]\n'+
         '    }\n'+
         '});'

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "broccoli-rollup": "^2.0.0",
     "broccoli-source": "^1.1.0",
     "broccoli-stew": "^1.5.0",
+    "camel-case": "^3.0.0",
     "ember-ast-helpers": "0.3.5",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.3",

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -31,6 +31,7 @@
 <div>{{fa-icon icon='book' fixedWidth=true class="MistyRose"}} Library</div>
 <div>{{fa-icon icon='pencil-alt' fixedWidth=true class="MistyRose"}} Applications</div>
 <div>{{fa-icon icon='cog' fixedWidth=true class="MistyRose"}} Settings</div>
+<div>{{fa-icon icon='fax' fixedWidth=true class="MistyRose"}} Contact</div>
 
 <h3>List Icons</h3>
 <ul class="fa-ul">

--- a/vendor/broccoli-fontawesome-pack.js
+++ b/vendor/broccoli-fontawesome-pack.js
@@ -3,6 +3,7 @@
 var Plugin = require('broccoli-plugin')
 var path = require('path')
 var fs = require('fs')
+var { config } = require('@fortawesome/fontawesome-svg-core');
 
 module.exports = FontAwesomePack
 FontAwesomePack.prototype = Object.create(Plugin.prototype)
@@ -17,7 +18,7 @@ function FontAwesomePack(inputNodes, options) {
 
   if(!pack) throw new Error("Required 'pack' option not specified")
   if(!(icons === 'all' || Array.isArray(icons)))
-    throw new Error("icons option must be either 'all' or an array of icon names like 'faCoffee'")
+    throw new Error("icons option must be either 'all' or an array of icon names like 'coffee'")
   if(!output) throw new Error("Required 'output' option not specified")
 
   this.options = {
@@ -46,12 +47,19 @@ FontAwesomePack.prototype.build = function() {
   if(this.options.icons === 'all'){
     selectedIcons = Object.keys(pack[pack.prefix])
   } else {
-    selectedIcons = this.options.icons
+    selectedIcons = this.options.icons.map(iconName => {
+      const prefix = config.familyPrefix;
+      if (iconName.substr(0, 2) === prefix) {
+        return iconName;
+      }
+
+      return prefix + iconName.charAt(0).toUpperCase() + iconName.substr(1);
+    });
   }
 
   const packageContents = `
-    export { 
-      ${ selectedIcons.join(',') } 
+    export {
+      ${ selectedIcons.join(',') }
     }  from '@fortawesome/${this.options.pack}/index.es.js'
   `
   const _thisPlugin = this

--- a/vendor/broccoli-fontawesome-pack.js
+++ b/vendor/broccoli-fontawesome-pack.js
@@ -3,6 +3,7 @@
 var Plugin = require('broccoli-plugin')
 var path = require('path')
 var fs = require('fs')
+var camelCase = require('camel-case')
 var { config } = require('@fortawesome/fontawesome-svg-core');
 
 module.exports = FontAwesomePack
@@ -47,13 +48,15 @@ FontAwesomePack.prototype.build = function() {
   if(this.options.icons === 'all'){
     selectedIcons = Object.keys(pack[pack.prefix])
   } else {
+    const prefix = config.familyPrefix;
+    //Look for icons which already contain the prefix as eg `faPencil` or `fa-pencil` without catching `fax`
+    const regexp = new RegExp(`^${prefix}([A-Z]|-)`);
     selectedIcons = this.options.icons.map(iconName => {
-      const prefix = config.familyPrefix;
-      if (iconName.substr(0, 2) === prefix) {
-        return iconName;
+      if (!regexp.test(iconName)) {
+        iconName = `${prefix}-${iconName}`;
       }
 
-      return prefix + iconName.charAt(0).toUpperCase() + iconName.substr(1);
+      return camelCase(iconName);
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1484,6 +1484,13 @@ callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
+camel-case@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
+  dependencies:
+    no-case "^2.2.0"
+    upper-case "^1.1.1"
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -6290,6 +6297,10 @@ untildify@^2.1.0:
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-2.1.0.tgz#17eb2807987f76952e9c0485fc311d06a826a2e0"
   dependencies:
     os-homedir "^1.0.0"
+
+upper-case@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
When importing icons it is confusing that the component requires them to
be named differently from the list of imported icons. This changes the
documentation and allows icons to be specified without the fa prefix.
For backwards compatibility and convenience the prefixed names are
still allowed.

Fixes #29