### PR TITLE
Do not crash on null icon

### DIFF
--- a/addon/components/fa-icon.js
+++ b/addon/components/fa-icon.js
@@ -30,8 +30,8 @@ function classList (previousClasses) {
 }
 
 function normalizeIconArgs (prefix, icon) {
-  if (icon === null) {
-    return null
+  if (!icon) {
+    return { prefix: 'fas', iconName: null };
   }
 
   if (typeof icon === 'object' && icon.prefix && icon.iconName) {


### PR DESCRIPTION
It should only display a log alerting the dev to check, but it should not throw as it does now.