### PR TITLE
defaultPrefix configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,28 @@ let app = new EmberApp(defaults, {
 
 ## Usage
 
+### Configuration
+
+Out of the box, icons will use the Solid style unless a prefix is manually specified.
+To change the default to Regular or Light, add a `fontawesome` configuration object
+to your application's `environment.js` and set the `defaultPrefix` option.
+
+```js
+module.exports = function(environment) {
+  let ENV = {
+    // Add options here
+    fontawesome: {
+      defaultPrefix: 'fal' // light icons
+    }
+  };
+  // ...
+  return ENV;
+};
+```
+
+As a reminder, the free version of Font Awesome does not include a complete set of icons
+for any style other than Solid, so this setting is recommended only for Pro subscribers.
+
 ### Template
 
 This is what it can look like in your template:
@@ -139,13 +161,13 @@ This is what it can look like in your template:
 {{fa-icon 'coffee'}}
 ```
 
-Without a prefix specified, the default `fas` is assumed:
+Without a prefix specified, the default specified in `environment.js` (or `fas`, if none set) is assumed:
 
 ```hbs
 {{fa-icon 'square'}}
 ```
 
-**If you want to use an icon from any style other than solid, you must use `prefix=`.**
+If you want to use an icon from any style other than the default, use `prefix=`.
 
 ```hbs
 {{fa-icon 'square' prefix='far'}}

--- a/addon/components/fa-icon.js
+++ b/addon/components/fa-icon.js
@@ -7,7 +7,7 @@ import { computed, getWithDefault } from '@ember/object'
 import appConfig from 'ember-get-config';
 
 function getConfigOption (key, defaultValue) {
-  return getWithDefault(appConfig, `environment.fontawesome.${key}`, defaultValue);
+  return getWithDefault(appConfig, `fontawesome.${key}`, defaultValue);
 }
 
 function objectWithKey (key, value) {

--- a/addon/components/fa-icon.js
+++ b/addon/components/fa-icon.js
@@ -3,7 +3,12 @@ import layout from '../templates/components/fa-icon'
 import Ember from 'ember'
 import { icon, parse, toHtml, config } from '@fortawesome/fontawesome-svg-core'
 import { htmlSafe } from '@ember/string'
-import { computed } from '@ember/object'
+import { computed, getWithDefault } from '@ember/object'
+import appConfig from 'ember-get-config';
+
+function getConfigOption (key, defaultValue) {
+  return getWithDefault(appConfig, `environment.fontawesome.${key}`, defaultValue);
+}
 
 function objectWithKey (key, value) {
   return ((Array.isArray(value) && value.length > 0) || (!Array.isArray(value) && value)) ? {[key]: value} : {}
@@ -30,8 +35,10 @@ function classList (previousClasses) {
 }
 
 function normalizeIconArgs (prefix, icon) {
+  const defaultPrefix = getConfigOption('defaultPrefix', 'fas');
+
   if (!icon) {
-    return { prefix: 'fas', iconName: null };
+    return { prefix: defaultPrefix, iconName: null };
   }
 
   if (typeof icon === 'object' && icon.prefix && icon.iconName) {
@@ -43,7 +50,7 @@ function normalizeIconArgs (prefix, icon) {
   }
 
   if (typeof icon === 'string') {
-    return { prefix: 'fas', iconName: icon }
+    return { prefix: defaultPrefix, iconName: icon }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ember-ast-helpers": "0.3.5",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.3",
+    "ember-get-config": "^0.2.4",
     "glob": "^7.1.2",
     "rollup-plugin-node-resolve": "^3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2344,6 +2344,13 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
+ember-get-config@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
+  dependencies:
+    broccoli-file-creator "^1.1.1"
+    ember-cli-babel "^6.3.0"
+
 ember-load-initializers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-1.0.0.tgz#4919eaf06f6dfeca7e134633d8c05a6c9921e6e7"


### PR DESCRIPTION
Closes #35.

Figured I'd take a stab at this. The gist is this PR adds the ability to specify a default `fa-icon` prefix in an app's environment.js configuration file, like so:

```js
// app/config/environment.js

module.exports = function(environment) {
  let ENV = {

    // ...standard Ember environment config stuff goes here.

    fontawesome: {
      defaultPrefix: 'fal' // light icons
    }
  };

  // ...

  return ENV;
};
```

If this option is missing, the prefix defaults to `'fas'`, as before.

I haven't written an explicit unit test for this yet since I wasn't sure how best to simulate modifying the environment config in test-land. Suggestions are welcome.

Anyhow, there's talk in the linked issue about maybe making this a core Font Awesome option rather than anything Ember-specific, but if y'all decide to go this route anyway, here's a starting point. Hope this helps either way!