### PR TITLE
Consolidate Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,25 +115,29 @@ Using the Pro packages requires [additional configuration](https://fontawesome.c
 
 If you want to include only a subset of icons from an icon pack, add a
 `fontawesome` configuration object to your applications options in
-`ember-cli-build.js`. The following example declares that all icons in
+`environment.js`. The following example declares that all icons in
 `free-solid-svg-icons` should be included in the `vendor.js` bundle add
 added to the library, and for `pro-light-svg-icons`, only `adjust`,
 `ambulance`, and `pencil-alt` are to be included in the bundle and added to the library.
 
-```
-// ...
-let app = new EmberApp(defaults, {
-  // Add options here
-  fontawesome: {
-    icons: {
-      'free-solid-svg-icons': 'all'
-      'pro-light-svg-icons': [
-        'adjust',
-        'ambulance',
-        'pencil-alt'
-       ]
+```js
+module.exports = function(environment) {
+  let ENV = {
+    // Add options here
+    fontawesome: {
+      icons: {
+        'free-solid-svg-icons': 'all'
+        'pro-light-svg-icons': [
+          'adjust',
+          'ambulance',
+          'pencil-alt'
+        ]
+      }
     }
-})
+  };
+  // ...
+  return ENV;
+};
 ```
 
 ## Usage

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,27 +6,6 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon')
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
     // Add options here
-    fontawesome: {
-      enableExperimentalBuildTimeTransform: true,
-      icons: {
-        'free-solid-svg-icons': [
-          'coffee',
-          'magic',
-          'circle',
-          'square',
-          'home',
-          'info',
-          'book',
-          'pencil-alt',
-          'cog',
-          'spinner',
-          'checkSquare',
-          'fax',
-          'sync'
-        ],
-        'free-regular-svg-icons': 'all',
-      }
-    }
   })
 
   /*

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -16,6 +16,28 @@ module.exports = function(environment) {
         Date: false
       }
     },
+    fontawesome: {
+      defaultPrefix: 'fas',
+      enableExperimentalBuildTimeTransform: true,
+      icons: {
+        'free-solid-svg-icons': [
+          'coffee',
+          'magic',
+          'circle',
+          'square',
+          'home',
+          'info',
+          'book',
+          'pencil-alt',
+          'cog',
+          'spinner',
+          'checkSquare',
+          'fax',
+          'sync'
+        ],
+        'free-regular-svg-icons': 'all',
+      }
+    },
 
     APP: {
       // Here you can pass flags/options to your application instance


### PR DESCRIPTION
In order to have a consistent configuration experience I've moved the
options that were in `ember-cli-build.js` into `environment.js`. Since
we need some configuration at both build and run time this is the best
place for it.

To provide for a smooth upgrade path existing configuration in
`ember-cli-build.js` will be respected, but a warning will be printed
during the build.  Any configuration in `environment.js` will supersede
anything in `ember-cli.build.js`

Fixes #57