### PR TITLE
Honor the default prefix in build time transform

### DIFF
--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -59,7 +59,7 @@ class AstTransform {
       }
     }
     const prefixHash = node.hash.pairs.find(obj => obj.key === 'prefix');
-    prefix = prefixHash ? prefixHash.value.value : 'fas';
+    prefix = prefixHash ? prefixHash.value.value : this.addon.fontawesomeConfig.defaultPrefix;
 
     if (!getAbstractIcon(icon, prefix)) {
       this.addon.ui.writeWarnLine(`${this.addon.name}: Unable to load icon '${icon}' with prefix '${prefix}'.`);

--- a/lib/build-time-components/fa-icon.js
+++ b/lib/build-time-components/fa-icon.js
@@ -9,6 +9,7 @@ module.exports = class FaIconComponent extends BuildTimeComponent {
   constructor(node, opts = {}) {
     super(node, Object.assign({ tagName: 'svg', ariaHidden: true }, opts));
     this._syntax = opts.transform.syntax;
+    this._defaultPrefix = opts.transform.addon.fontawesomeConfig.defaultPrefix;
     this.classNames = [getReplacementClass()];
     this.classNameBindings = [
       'icon',
@@ -72,7 +73,7 @@ module.exports = class FaIconComponent extends BuildTimeComponent {
     const iconName = iconObject.original ? iconObject.original : null;
 
     const prefixObject = this.invocationAttrs.prefix;
-    const prefix = (prefixObject && prefixObject.original) ? prefixObject.original : 'fas';
+    const prefix = (prefixObject && prefixObject.original) ? prefixObject.original : this._defaultPrefix;
     if (iconName && iconName !== 'icon') {
       return getAbstractIcon(iconName, prefix);
     }


### PR DESCRIPTION
When a default prefix is specified it should work in icons that are
transformed at build time.

Fixes #65