### PR TITLE
Bind string like objects to title

### DIFF
--- a/addon/components/fa-icon.js
+++ b/addon/components/fa-icon.js
@@ -101,7 +101,10 @@ const IconComponent = Component.extend({
     const transform = objectWithKey('transform', (typeof transformProp === 'string') ? parse.transform(transformProp) : transformProp)
     const mask = objectWithKey('mask', normalizeIconArgs(null, this.get('mask')))
     const symbol = this.getWithDefault('symbol', false)
-    const title = this.getWithDefault('title', null)
+    let title = this.getWithDefault('title', null)
+    if (title) {
+      title = `${title}`;
+    }
 
     const o = assign({},
       classes,

--- a/tests/integration/components/fa-icon-test.js
+++ b/tests/integration/components/fa-icon-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit'
 import hbs from 'htmlbars-inline-precompile'
+import { htmlSafe } from '@ember/string';
 
 const faCoffee = {
   prefix: 'fas',
@@ -95,4 +96,16 @@ test('no title attribute gives no title element', function (assert) {
   this.render(hbs`{{fa-icon icon=faCoffee}}`);
 
   assert.equal(this.$('svg title').length, 0, 'has not title element');
+});
+
+test('title from string like object', function (assert) {
+  assert.expect(2);
+  const title = 'awesome is as awesome does';
+  this.set('title', htmlSafe(title));
+  this.set('faCoffee', faCoffee);
+
+  this.render(hbs`{{fa-icon icon=faCoffee title=title}}`);
+
+  assert.equal(this.$('svg title').length, 1, 'has title element');
+  assert.equal(this.$('svg title').text().trim(), title, 'title is correct');
 });


### PR DESCRIPTION
Translation libraries for Ember don't return plain strings, they often
return Handlebars objects that are HTML safe. Ensure that these objects
can work as titles by casting them back into a plain string.

This casting feels a little bit sloppy to me, but I couldn't come up with anything prettier. Open to any suggestions.