### PR TITLE
move development dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,21 +44,16 @@
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.0",
     "broccoli-file-creator": "^1.1.1",
-    "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-plugin": "^1.3.0",
     "broccoli-rollup": "^2.0.0",
     "broccoli-source": "^1.1.0",
-    "broccoli-stew": "^1.5.0",
     "camel-case": "^3.0.0",
     "ember-ast-helpers": "0.3.5",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.3",
     "ember-get-config": "^0.2.4",
     "glob": "^7.1.2",
-    "husky": "^0.14.3",
-    "lint-staged": "^7.2.0",
-    "markdown-toc": "^1.2.0",
     "rollup-plugin-node-resolve": "^3.0.2"
   },
   "devDependencies": {
@@ -87,7 +82,11 @@
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^6.0.1",
     "loader.js": "^4.2.3",
-    "qunit-dom": "^0.6.2"
+    "qunit-dom": "^0.6.2",
+    "husky": "^0.14.3",
+    "lint-staged": "^7.2.0",
+    "markdown-toc": "^1.2.0",
+    "broccoli-stew": "^1.5.0"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"


### PR DESCRIPTION
hello, I noticed some strange dependencies showing up in my tree (husky, namely) and audited back to the package.json of this project.

- broccoli-funnel was unused
- broccoli-stew was used only for debugging
- husky, lint-staged, and markdown-toc are not used when consuming addon

these changes will improve developer experience using this addon in their projects.

thanks