### PR TITLE
Allow users to opt out of the no-icons warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,20 @@ module.exports = function(environment) {
 };
 ```
 
+By default, `ember-fontawesome` will warn if no icons are being included
+in the build. To disable this behavior (e.g. if icons are being added by
+some other means), set `warnIfNoIconsIncluded` to `false`.
+
+
+```js
+let ENV = {
+  fontawesome: {
+    warnIfNoIconsIncluded: false,
+    // ...
+  }
+};
+```
+
 ## Usage
 
 ### Configuration

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ module.exports = {
         }, this.fontawesomeConfig);
     }
 
-    if(Object.keys(this.fontawesomeConfig.icons).length === 0) {
+    if(Object.keys(this.fontawesomeConfig.icons).length === 0 && this.fontawesomeConfig.warnIfNoIconsIncluded !== false) {
       this.ui.writeWarnLine(
         'No icons are included in your build configuration.\n'+
         'Any icon packs you install under node_modules will be bundled into vendor.js\n'+


### PR DESCRIPTION
We're including sets of icons in our build via an addon we publish to our internal npm registry, but we'd still like to use the runtime portions of `ember-fontawesome` — this has been working great, except that the warning message it emits when it's not aware of any icons is pretty noisy. This PR adds a flag to opt out of that message.

I didn't see any testing for the build-time portions of the code here (beyond what's implicit with the runtime tests), so I'm not sure if there's a way to add coverage for this. If you have thoughts on how to accomplish that, I'm happy to add tests.