### PR TITLE
Allow Addons to Add Icons to the Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Using the Pro packages requires [additional configuration](https://fontawesome.c
 If you want to include only a subset of icons from an icon pack, add a
 `fontawesome` configuration object to your applications options in
 `environment.js`. The following example declares that all icons in
-`free-solid-svg-icons` should be included in the `vendor.js` bundle add
+`free-solid-svg-icons` should be included in the `vendor.js` bundle and
 added to the library, and for `pro-light-svg-icons`, only `adjust`,
 `ambulance`, and `pencil-alt` are to be included in the bundle and added to the library.
 
@@ -159,6 +159,28 @@ let ENV = {
   }
 };
 ```
+
+### Using within an addon
+
+If you want to use icons in your addon there are a few steps to take. 
+
+First ensure `@fortawesome/ember-fontawesome` and any icon packs are in 
+the `dependencies` section of your `package.json`. This makes them available
+to the apps that use your addon. 
+
+Second you need to declare what icons you are using so apps that subset icons 
+will know what to include. You do this in `config/icons.js`. The format is:
+
+```js
+module.exports = function() {
+  return {
+    'free-solid-svg-icons': ['bacon', 'pencil'],
+    'free-brands-svg-icons': ['font-awesome-flag'],
+  };
+};
+```
+
+You should avoid listing any Font Awesome Pro packages as dependencies unless you are confident that whoever is using your addon has access to those.
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var FontAwesomePack = require('./vendor/broccoli-fontawesome-pack')
 var FontAwesomeAutoLibrary = require('./vendor/broccoli-fontawesome-auto-library')
 var glob = require('glob')
 var buildAstTransform = require('./lib/ast-transform');
+const { discoverConfiguredIcons, combineIconSets } = require('./lib/discover-configured-icons');
 var writeFile = require('broccoli-file-creator');
 const { config, dom } = require('@fortawesome/fontawesome-svg-core');
 const path = require('path');
@@ -114,8 +115,11 @@ module.exports = {
       `);
       buildConfig = addonOptions.fontawesome;
     }
+    const mergedConfig = Object.assign(configDefaults, buildConfig, appConfig);
+    const configuredIcons = discoverConfiguredIcons(this.app.project);
+    mergedConfig.icons = combineIconSets(mergedConfig.icons, configuredIcons);
 
-    this.fontawesomeConfig = Object.assign(configDefaults, buildConfig, appConfig);
+    this.fontawesomeConfig = mergedConfig;
   },
 
   includeIconPackages() {

--- a/lib/discover-configured-icons.js
+++ b/lib/discover-configured-icons.js
@@ -1,0 +1,53 @@
+/* eslint-env node */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const unique = require('array-unique');
+
+function discoverConfiguredIcons(project) {
+  const projectIcons = path.join(project.root, 'config', 'icons.js');
+  const icons = getIcons(project, projectIcons);
+
+  return icons;
+}
+
+function processAddons(addons) {
+  const allIcons = addons.map(addon => {
+    const iconPath = path.join(addon.root, 'config', 'icons.js');
+    return getIcons(addon, iconPath);
+  });
+
+  return allIcons.reduce((accumulator, obj) => {
+    return combineIconSets(accumulator, obj);
+  }, {});
+}
+
+function getIcons(project, iconPath) {
+  let addonIcons = processAddons(project.addons);
+  let projectIcons = {};
+  if (fs.existsSync(iconPath)) {
+    projectIcons = require(iconPath)();
+  }
+
+  return combineIconSets(addonIcons, projectIcons);
+}
+
+function combineIconSets(set1, set2) {
+  for (let key in set2) {
+    if (!(key in set1)) {
+      set1[key] = [];
+    }
+    //'all' value trumps any icons in an array
+    if (set1[key] === 'all' || set2[key] === 'all') {
+      set1[key] = 'all';
+    } else {
+      set1[key] = unique([...set1[key], ...set2[key]]);
+    }
+  }
+
+  return set1;
+}
+
+module.exports = { discoverConfiguredIcons, combineIconSets };


### PR DESCRIPTION
Instead of relying on the app to discover and include needed icons, this
allows each addon to register their needs in `config/icons.js` and they will be
picked up by the app and added to the final build.

Hoping for feedback on the file location and the format before I write any docs. Addons would supply icons as a module:
```
module.exports = function() {
  return {
    'free-solid-svg-icons': 'all',
    'free-brands-svg-icons': [
      'black-tie'
    ],
  };
};
```
I've elected to wrap it in a function in case we want to provide arguments in the future.  Other addons like [ember-intl](https://github.com/ember-intl/ember-intl) consolidate configuration like this and I think it is a good pattern here.  

Another option I considered would be to read any icon configuration in the addon `config/environment.js` and bundle it into the app, but `ember-cli` currently does a shallow merge of those options into the app which wouldn't include combining the `icons` options together. I feel like having our own configuration file is actually a bit less surprising than having a single option in the addons `environment.js` file which is magically merged into the app configuration.

Steps after this is complete would include:
1. Deprecating the `icons` option in the `environment.js` of apps and addons
2. Auto detecting static icon names in templates so addons don't need to list everything manually or creating some kind of test integration like [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow) does that would find icon names and make it easy to create the `icons.js` file (or maybe both!)