### PR TITLE
Add yarn workspace support

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "ember-cli-babel": "^7.1.2",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-get-config": "^0.2.4",
+    "find-yarn-workspace-root": "^1.2.1",
     "glob": "^7.1.2",
     "rollup-plugin-node-resolve": "^4.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4314,7 +4314,7 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-find-yarn-workspace-root@^1.1.0:
+find-yarn-workspace-root@^1.1.0, find-yarn-workspace-root@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
   integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==


### PR DESCRIPTION
Instead of expecting `node_modules` to be at the app root this detects the
location and modifies it for yarn workspaces.

Fixes #51