### PR TITLE
Fix issue with build time transform in nested addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ module.exports = {
   },
   included(app) {
     this._super.included.apply(this, arguments)
-
+    const originalApp = app;
     let current = this;
     // Keep iterating upward until we don't have a grandparent.
     // Has to do this grandparent check because at some point we hit the project.
@@ -178,7 +178,7 @@ module.exports = {
     this.readConfig();
     this.includeIconPackages();
 
-    this.setupPreprocessorRegistryAfterConfiguration('parent', app.registry);
+    this.setupPreprocessorRegistryAfterConfiguration('parent', originalApp.registry);
 
     app.import('vendor/fontawesome.js')
     Object.keys(this.fontawesomeConfig.icons).forEach(pack => {


### PR DESCRIPTION
We were sending the parent app to the pre-processor, which precludes
addons transforming their own templates. Instead we need to ensure this
is called with the addon itself.