### PR TITLE
Restrict what files get published

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,5 +99,20 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "defaultBlueprint": "ember-fontawesome"
-  }
+  },
+  "files": [
+    "CHANGELOG.md",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
+    "LICENSE.md",
+    "UPGRADING.md",
+    "ember-cli-build.js",
+    "index.js",
+    "addon/",
+    "app/",
+    "blueprints/",
+    "config/",
+    "lib/",
+    "vendor/"
+  ]
 }


### PR DESCRIPTION
Prevents accidentally including editor configuration, history, and any
other random files or directories that might be laying around.