### PR TITLE
use explicit local reference in fa-icon template

### DIFF
--- a/addon/templates/components/fa-icon.hbs
+++ b/addon/templates/components/fa-icon.hbs
@@ -1,1 +1,1 @@
-{{html}}
+{{this.html}}


### PR DESCRIPTION
This avoids ember trying to look up `html` as a helper or component. 

Newer ember versions have changed their resolver, and this was causing issues when I updated to Ember 3.8.