### PR TITLE
add attributes for usage inside svg

### DIFF
--- a/addon/components/fa-icon.js
+++ b/addon/components/fa-icon.js
@@ -74,6 +74,10 @@ const IconComponent = Component.extend({
     'xmlns',
     'viewBox',
     'safeStyle:style',
+    'width',
+    'height',
+    'x',
+    'y',
   ],
   html: computed('abstractIcon.children.[]', function() {
     const abstractIcon = this.get('abstractIcon');


### PR DESCRIPTION
When used inside a `svg` theese attributes allow effective styling by doing something like `{{fa-icon 'home' width=20 height=20}}`.