### PR TITLE
Prevent loading duplicate classes

### DIFF
--- a/addon/components/fa-icon.js
+++ b/addon/components/fa-icon.js
@@ -15,7 +15,7 @@ function objectWithKey (key, value) {
   return ((Array.isArray(value) && value.length > 0) || (!Array.isArray(value) && value)) ? {[key]: value} : {}
 }
 
-function classList (previousClasses) {
+function classList () {
   let classes = {
     'fa-spin': this.get('spin'),
     'fa-pulse': this.get('pulse'),
@@ -32,7 +32,6 @@ function classList (previousClasses) {
   return Object.keys(classes)
     .map(key => classes[key] ? key : null)
     .filter(key => key)
-    .concat(previousClasses.filter(c => !c.match(/^fa-/)))
 }
 
 function normalizeIconArgs (prefix, icon) {
@@ -95,7 +94,6 @@ const IconComponent = Component.extend({
   }),
   abstractIcon: computed(
     'prefix',
-    'class',
     'icon',
     'transform',
     'mask',
@@ -112,7 +110,7 @@ const IconComponent = Component.extend({
     'pull',
     function () {
     const iconLookup = normalizeIconArgs(this.get('prefix'), this.get('icon'))
-    const classes = objectWithKey('classes', [...classList.bind(this)(this.getWithDefault('class', '').split(' '))])
+    const classes = objectWithKey('classes', [...classList.bind(this)()])
     const transformProp = this.get('transform')
     const transform = objectWithKey('transform', (typeof transformProp === 'string') ? parse.transform(transformProp) : transformProp)
     const mask = objectWithKey('mask', normalizeIconArgs(null, this.get('mask')))
@@ -143,14 +141,13 @@ const IconComponent = Component.extend({
   }),
   allClasses: computed('abstractIcon', 'attributes.class', 'class', function () {
     const abstractIcon = this.get('abstractIcon');
-    const attributes = this.get('attributes');
-    const classes = this.get('class');
-    const iconClasses = getWithDefault(attributes, 'class');
     if (!abstractIcon) {
       return config.replacementClass;
     }
+    const attributes = this.get('attributes');
+    const iconClasses = getWithDefault(attributes, 'class');
 
-    return `${iconClasses} ${classes}`;
+    return iconClasses;
   }),
   'data-prefix': computed('attributes.data-prefix', function () {
     const attributes = this.get('attributes');

--- a/tests/integration/components/fa-icon-test.js
+++ b/tests/integration/components/fa-icon-test.js
@@ -42,10 +42,30 @@ module('Integration | Component | fa icon', function(hooks) {
     this.set('faCoffee', faCoffee)
     this.set('class', 'foo-xyz')
     await render(hbs`<FaIcon @icon={{this.faCoffee}} class={{this.class}} />`)
-    assert.ok(find('svg').getAttribute('class').split(/\s+/).includes('foo-xyz'))
+    assert.dom('svg').hasClass('foo-xyz')
     this.set('class', 'foo-new-class')
-    assert.notOk(find('svg').getAttribute('class').split(/\s+/).includes('foo-xyz'))
-    assert.ok(find('svg').getAttribute('class').split(/\s+/).includes('foo-new-class'))
+    assert.dom('svg').doesNotHaveClass('foo-xyz')
+    assert.dom('svg').hasClass('foo-new-class')
+  })
+
+  test('it renders extra classes only once #98 in classic invocation', async function(assert) {
+    const extraClass = 'foo-xyz';
+    this.set('faCoffee', faCoffee)
+    this.set('class', extraClass)
+    await render(hbs`{{fa-icon icon=this.faCoffee class=this.class}}`)
+    assert.dom('svg').hasClass(extraClass)
+    const list = find('svg').getAttribute('class').split(' ')
+    const instances = list.filter(val => val === extraClass);
+    assert.equal(instances.length, 1, 'class appears only once')
+  })
+
+  test('it does not render "undefined" classes', async function(assert) {
+    this.set('faCoffee', faCoffee)
+    await render(hbs`<FaIcon @icon={{this.faCoffee}} class='test' />`)
+    assert.dom('svg').hasClass('test')
+    const list = find('svg').getAttribute('class').split(' ')
+    const instances = list.filter(val => val === 'undefined');
+    assert.equal(instances.length, 0)
   })
 
   test('it renders coffee positional', async function(assert) {


### PR DESCRIPTION
Ember automatically binds any `class` passed in to the component
element. We were also adding this to both the attributes provided by
font awesome as well as our own classNameBindings resulting in multiple
instances of the same class being added.

Fixes #98