### PR TITLE
Prefer icons.js for subsetting icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,29 +121,22 @@ Using the Pro packages requires [additional configuration](https://fontawesome.c
 ### Subsetting icons
 
 If you want to include only a subset of icons from an icon pack, add a
-`fontawesome` configuration object to your applications options in
-`environment.js`. The following example declares that all icons in
-`free-solid-svg-icons` should be included in the `vendor.js` bundle and
-added to the library, and for `pro-light-svg-icons`, only `adjust`,
-`ambulance`, and `pencil-alt` are to be included in the bundle and added to the library.
+`config/icons.js` file listing the icons you want to include.
+The following example declares that all icons in
+`free-solid-svg-icons` should be included build, 
+and, only `adjust`, `ambulance`, and `pencil-alt` from `pro-light-svg-icons`
+are to be included.
 
 ```js
-module.exports = function(environment) {
-  let ENV = {
-    // Add options here
-    fontawesome: {
-      icons: {
-        'free-solid-svg-icons': 'all',
-        'pro-light-svg-icons': [
-          'adjust',
-          'ambulance',
-          'pencil-alt'
-        ]
-      }
-    }
+module.exports = function() {
+  return {
+    'free-solid-svg-icons': 'all',
+    'pro-light-svg-icons': [
+      'adjust',
+      'ambulance',
+      'pencil-alt'
+    ]
   };
-  // ...
-  return ENV;
 };
 ```
 

--- a/index.js
+++ b/index.js
@@ -115,6 +115,14 @@ module.exports = {
       `);
       buildConfig = addonOptions.fontawesome;
     }
+    if ('icons' in appConfig) {
+      this.ui.writeWarnLine(`Configuring icons in config/environment.js is no longer recommended
+      and will be removed in a future version.
+
+      Move icon list to config/icons.js for better performance.
+      See https://github.com/FortAwesome/ember-fontawesome#subsetting-icons for instructions.
+      `);
+    }
     const mergedConfig = Object.assign(configDefaults, buildConfig, appConfig);
     const configuredIcons = discoverConfiguredIcons(this.app.project);
     mergedConfig.icons = combineIconSets(mergedConfig.icons, configuredIcons);

--- a/lib/discover-configured-icons.js
+++ b/lib/discover-configured-icons.js
@@ -7,7 +7,7 @@ const path = require('path');
 const unique = require('array-unique');
 
 function discoverConfiguredIcons(project) {
-  const projectIcons = path.join(project.root, 'config', 'icons.js');
+  const projectIcons = path.join(path.dirname(project.configPath()), 'icons.js');
   const icons = getIcons(project, projectIcons);
 
   return icons;

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -18,25 +18,7 @@ module.exports = function(environment) {
     },
     fontawesome: {
       defaultPrefix: 'fas',
-      enableExperimentalBuildTimeTransform: true,
-      icons: {
-        'free-solid-svg-icons': [
-          'coffee',
-          'magic',
-          'circle',
-          'square',
-          'home',
-          'info',
-          'book',
-          'pencil-alt',
-          'cog',
-          'spinner',
-          'checkSquare',
-          'fax',
-          'sync'
-        ],
-        'free-regular-svg-icons': 'all',
-      }
+      enableExperimentalBuildTimeTransform: false,
     },
 
     APP: {

--- a/tests/dummy/config/icons.js
+++ b/tests/dummy/config/icons.js
@@ -1,0 +1,20 @@
+module.exports = function() {
+  return {
+    'free-solid-svg-icons': [
+      'coffee',
+      'magic',
+      'circle',
+      'square',
+      'home',
+      'info',
+      'book',
+      'pencil-alt',
+      'cog',
+      'spinner',
+      'checkSquare',
+      'fax',
+      'sync'
+    ],
+    'free-regular-svg-icons': 'all',
+  };
+};


### PR DESCRIPTION
Storing long lists of icons in environment.js results in very large meta
tags for the application. Since these have to be parsed before content
can be shown this can slow down the loading of boot animations that are
intended to load before the application is parsed.

Fixes #112