### PR TITLE
Don't add styles to application twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,6 +189,7 @@ module.exports = {
       app.import(`vendor/${pack}.js`)
     })
     app.import('vendor/autoLibrary.js')
+    app.import('vendor/configure-fontawesome-styles.js')
 
     config.autoAddCss = false;
     app.import('vendor/fontawesome.css');

--- a/tests/acceptance/styles-test.js
+++ b/tests/acceptance/styles-test.js
@@ -1,0 +1,15 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+module('Acceptance | styles', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('fontawesome styles are not injected into the document', async function(assert) {
+    await visit('/');
+    assert.equal(currentURL(), '/');
+    const styleTags = document.getElementsByTagName('style');
+    const faStyles = Array.from(styleTags).filter(el => el.textContent.includes('.fa'));
+    assert.equal(faStyles.length, 0);
+  });
+});

--- a/vendor/configure-fontawesome-styles.js
+++ b/vendor/configure-fontawesome-styles.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var { config } = require('@fortawesome/fontawesome-svg-core');
+
+// turn off adding styles to the app's HTML as these styles are included in the build already
+config.autoAddCss = false;


### PR DESCRIPTION
We needed to switch this off in the application itself and not just in
the build to ensure these styles didn't get added twice (they are
already included in vendor.css).

Fixes #97