### PR TITLE
Fix assignment for IE

### DIFF
--- a/vendor/configure-fontawesome-styles.js
+++ b/vendor/configure-fontawesome-styles.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var { config } = require('@fortawesome/fontawesome-svg-core');
+var fontawesomeSvgCore = require('@fortawesome/fontawesome-svg-core');
 
 // turn off adding styles to the app's HTML as these styles are included in the build already
-config.autoAddCss = false;
+fontawesomeSvgCore.config.autoAddCss = false;


### PR DESCRIPTION
Destructuring assignments are not suppported in IE. Loading such code as
`var { config } =` in IE will result in an `Expected identifier` error.