### PR TITLE
Computed prop override deprecation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,13 +63,13 @@ We're seeking core contributors to help drive this project. Core contributors:
 
 * `git clone <repository-url>`
 * `cd my-addon`
-* `npm install`
+* `yarn`
 
 ## Linting
 
-* `npm run lint:hbs`
-* `npm run lint:js`
-* `npm run lint:js -- --fix`
+* `yarn lint:hbs`
+* `yarn lint:js`
+* `yarn lint:js -- --fix`
 
 ## Running tests
 

--- a/addon/components/fa-icon.js
+++ b/addon/components/fa-icon.js
@@ -169,17 +169,35 @@ const IconComponent = Component.extend({
     const attributes = this.get('attributes');
     return getWithDefault(attributes, 'data-fa-processed');
   }),
-  'aria-hidden': computed('attributes.aria-hidden', function () {
-    const attributes = this.get('attributes');
-    return getWithDefault(attributes, 'aria-hidden');
+  'aria-hidden': computed('attributes.aria-hidden', {
+    get() {
+      if (this._ariaHiddenOverride) {
+        return this._ariaHiddenOverride;
+      }
+      const attributes = this.get('attributes');
+      return getWithDefault(attributes, 'aria-hidden');
+    },
+    set(key, value) {
+      this._ariaHiddenOverride = value;
+      return value;
+    }
   }),
   'aria-labelledby': computed('attributes.aria-labelledby', function () {
     const attributes = this.get('attributes');
     return getWithDefault(attributes, 'aria-labelledby');
   }),
-  'focusable': computed('attributes.focusable', function () {
-    const attributes = this.get('attributes');
-    return getWithDefault(attributes, 'focusable');
+  'focusable': computed("attributes.focusable", {
+    get() {
+      if (this._focusableOverride) {
+        return this._focusableOverride;
+      }
+      const attributes = this.get("attributes");
+      return getWithDefault(attributes, "focusable");
+    },
+    set(key, value) {
+      this._focusableOverride = value;
+      return value;
+    }
   }),
   'role': computed('attributes.role', function () {
     const attributes = this.get('attributes');


### PR DESCRIPTION
## Purpose

The `aria-hidden` and `focusable` computed properties can be overridden, this behavior has been deprecated by Ember.

[Link to Ember deprecation guide](https://deprecations.emberjs.com/v3.x/#toc_computed-property-override)

Also, updates the contributing guide to use `yarn` over `npm`.

## Approach

Adds `get/set` functions to these properties.