### PR TITLE
update contribution guide to use yarn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,13 +63,13 @@ We're seeking core contributors to help drive this project. Core contributors:
 
 * `git clone <repository-url>`
 * `cd my-addon`
-* `npm install`
+* `yarn`
 
 ## Linting
 
-* `npm run lint:hbs`
-* `npm run lint:js`
-* `npm run lint:js -- --fix`
+* `yarn lint:hbs`
+* `yarn lint:js`
+* `yarn lint:js -- --fix`
 
 ## Running tests
 


### PR DESCRIPTION
Updates the contribution guide to use `yarn` instead of `npm`.