### PR TITLE
fix: lookup svg-core using require.resolve

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = {
 
   treeForVendor(vendorTree) {
     const iconRollups = []
-    const pathToCore = path.join(this._nodeModulesPath, '@fortawesome', 'fontawesome-svg-core');
+    const pathToCore = require.resolve('@fortawesome/fontawesome-svg-core');
 
     Object.keys(this.fontawesomeConfig.icons).forEach(pack => {
       const iconExportsFile = `exports-${pack}.js`

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = {
 
   treeForVendor(vendorTree) {
     const iconRollups = []
-    const pathToCore = path.dirname(require.resolve('@fortawesome/fontawesome-svg-core'));
+    const pathToCore = path.dirname(require.resolve('@fortawesome/fontawesome-svg-core/package.json'));
 
     Object.keys(this.fontawesomeConfig.icons).forEach(pack => {
       const iconExportsFile = `exports-${pack}.js`

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = {
 
   treeForVendor(vendorTree) {
     const iconRollups = []
-    const pathToCore = require.resolve('@fortawesome/fontawesome-svg-core');
+    const pathToCore = path.dirname(require.resolve('@fortawesome/fontawesome-svg-core'));
 
     Object.keys(this.fontawesomeConfig.icons).forEach(pack => {
       const iconExportsFile = `exports-${pack}.js`

--- a/index.js
+++ b/index.js
@@ -49,7 +49,6 @@ module.exports = {
             resolve()
           ]
         },
-        nodeModulesPath: this._nodeModulesPath,
         name: `${pack}-rollup`
       })
       iconRollups.push(rollupNode)
@@ -70,7 +69,6 @@ module.exports = {
           resolve()
         ]
       },
-      nodeModulesPath: this._nodeModulesPath,
       name: 'fontawesome-svg-core'
     })
 


### PR DESCRIPTION
Package managers move modules around all the time, and one of those moves is module hoisting, where it's moved up to a parent where a module can be share across multiple packages. See related issue: https://github.com/microsoft/rushstack/issues/1998