### PR TITLE
Removes prefixing behaviour before numbers.

### DIFF
--- a/tests/dummy/config/icons.js
+++ b/tests/dummy/config/icons.js
@@ -15,6 +15,7 @@ module.exports = function () {
       'checkSquare',
       'fax',
       'sync',
+      'stopwatch-20',
     ],
     'free-regular-svg-icons': 'all',
   };

--- a/vendor/broccoli-fontawesome-pack.js
+++ b/vendor/broccoli-fontawesome-pack.js
@@ -3,7 +3,7 @@
 var Plugin = require('broccoli-plugin')
 var path = require('path')
 var fs = require('fs')
-var { camelCase } = require('camel-case')
+var { camelCase, camelCaseTransformMerge } = require('camel-case')
 var { config } = require('@fortawesome/fontawesome-svg-core');
 
 class FontAwesomePack extends Plugin {
@@ -54,7 +54,7 @@ class FontAwesomePack extends Plugin {
           iconName = `${prefix}-${iconName}`;
         }
 
-        return camelCase(iconName);
+        return camelCase(iconName, { transform: camelCaseTransformMerge });
       });
     }
 


### PR DESCRIPTION
fixes #200 

see https://www.npmjs.com/package/camel-case#user-content-merge-numbers for details on this change to camelCasing.