### PR TITLE
Remove whitespace around icon

### DIFF
--- a/addon/components/fa-icon.hbs
+++ b/addon/components/fa-icon.hbs
@@ -1,4 +1,4 @@
-{{#if this.iconExists}}
+{{~#if this.iconExists~}}
     <svg
         style={{this.safeStyle}}
         class={{this.iconAttributes.class}}
@@ -17,4 +17,4 @@
     >
         {{this.content}}
     </svg>
-{{/if}}
+{{~/if~}}

--- a/tests/integration/components/fa-icon-test.js
+++ b/tests/integration/components/fa-icon-test.js
@@ -199,4 +199,11 @@ module('Integration | Component | fa icon', function (hooks) {
     assert.dom('svg').hasAttribute('x', '2');
     assert.dom('svg').hasAttribute('y', '2');
   });
+
+  test('it renders no surrounding whitespace', async function (assert) {
+    this.set('faCoffee', faCoffee);
+    await render(hbs`<FaIcon @icon={{this.faCoffee}} />`);
+    assert.ok(this.element.innerHTML.startsWith('<svg '));
+    assert.ok(this.element.innerHTML.endsWith('</svg>'));
+  });
 });


### PR DESCRIPTION
Putting an `<FaIcon>` inside of a link create an unsightly artifact where the link underline extends onto the whitespace around the icon. This changes remove that surrounding whitespace by using `~`. 