### PR TITLE
add back support for ember 3.28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
+          - ember-lts-3.28
           - ember-lts-4.4
           - ember-lts-4.8
           - ember-lts-4.12

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "node": "14.* || 16.* || >= 18"
       },
       "peerDependencies": {
-        "ember-source": "^4.0.0 || >=5.0.0"
+        "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "webpack": "^5.78.0"
   },
   "peerDependencies": {
-    "ember-source": "^4.0.0 || >=5.0.0"
+    "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -11,6 +11,17 @@ module.exports = async function () {
     },
     scenarios: [
       {
+        name: 'ember-lts-3.28',
+        npm: {
+          devDependencies: {
+            'ember-resolver': '^8.0.0',
+            'ember-source': '~3.28.0',
+            'ember-qunit': '^6.0.0',
+            '@ember/test-helpers': '^2.0.0',
+          },
+        },
+      },
+      {
         name: 'ember-lts-4.4',
         npm: {
           devDependencies: {


### PR DESCRIPTION
There is nothing implicit in this addon that is preventing support for Ember 3.28 so this PR widens the peerDependency on ember-source and adds 3.28 to the CI matrix

Edit: I'm not exactly sure why the `ci.yaml` diff is the whole file 🤔 if you turn on `hide whitespace` it shows the one line that I added so I'm assuming it's a change from tabs to spaces or something? your editor config file says it should be spaces so I assume my editor has updated them to what the config was expecting 👍 