### PR TITLE
Improve typing and docs recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ---
 
-For migration see https://github.com/FortAwesome/ember-fontawesome/pull/239
+For upgrading see [here](https://github.com/FortAwesome/ember-fontawesome/blob/3.x/UPGRADING.md)
 
 ---
 
-Previous 2.x CHANGELOG available https://github.com/FortAwesome/ember-fontawesome/blob/2.x/CHANGELOG.md
+Previous 2.x CHANGELOG is available [here](https://github.com/FortAwesome/ember-fontawesome/blob/2.x/CHANGELOG.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Removed
 * Drop support for `enableExperimentalBuildTimeTransform` (it was never documented)
 * Option `warnIfNoIconsIncluded` as it was used only in build time code (index.js) which doesn't exists in v2 addons
-* Remove ´config/icons.js` (you need to setup in app.js/ts, see migration process)
+* Remove `config/icons.js` (you need to setup in app.js/ts, see migration process)
 
 ### Fixed
 * Re-add support for ember v3.28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ---
 
-## [3.0.0](https://github.com/FortAwesome/ember-fontawesome/releases/tag/3.0.0) - 2025-02-03
+## [3.0.0](https://github.com/FortAwesome/ember-fontawesome/releases/tag/3.0.0) - 2025-02-11
 
 ### Changed
 * Convert addon to an ember v2 addon

--- a/README.md
+++ b/README.md
@@ -104,6 +104,64 @@ yarn add --dev @fortawesome/free-solid-svg-icons
 
 After installation you need to setup the package in your app by adding the section parts like bellow.
 
+### Using in Projects with Template Tag (.gjs / .gts) - Recommended
+
+If you are using [template tag](https://guides.emberjs.com/release/components/template-tag-format/) you can set it up as follows.
+With this approach, you can import icons directly in your template without needing to import each one individually in `font-awesome.js/ts`.
+
+To configure this setup, create `font-awesome.js/ts` with following content:
+
+```ts
+// app/font-awesome.ts
+import { config } from '@fortawesome/fontawesome-svg-core';
+import '@fortawesome/fontawesome-svg-core/styles.css'; // This adds the basic icon styles into your app
+
+// Disable auto CSS import into head. It solved the side effect for jumping icon size.
+// This is required to for Fastboot apps, otherwise build fails
+// It's the recommended way for setup Font Awesome in your app
+config.autoAddCss = false;
+```
+
+Import the created `font-awesome.js/ts` file in `app.js/ts`.
+
+```ts
+// app/app.ts
+import Application from '@ember/application';
+import Resolver from 'ember-resolver';
+import loadInitializers from 'ember-load-initializers';
+import config from 'app-name/config/environment';
+import './font-awesome'; // Add this import statement for Font Awesome setup
+
+export default class App extends Application {
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver;
+}
+
+loadInitializers(App, config.modulePrefix);
+```
+
+In your template, you can use icons like this:
+
+```gts
+// app/components/some-component.gts
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faSquare } from '@fortawesome/free-solid-svg-icons';
+
+<template>
+  <FaIcon @icon={{faSquare}} />
+</template>
+```
+
+With this approach, you no longer need to pass `@prefix` and the `defaultPrefix` configuration in `environment.js` will be ignored.
+However, when using this setup, you must always pass the icon definition instead of a string. Otherwise, the icon will not render, and a warning will appear in the developer console.
+
+Note:
+This setup also works with `.hbs` files, but it is more complex to use.
+
+
+### Classic setup (if you don't have Template Tag)
+
 Create `app/font-awesome.js/ts` with following content
 
 ```ts
@@ -280,18 +338,23 @@ If you want to use an icon from any style other than the default, use `prefix=`.
 <FaIcon @icon="square" @prefix="far" />
 ```
 
-Note: The packages also allows passing `@icon` as an object, as shown below:
+Note:
+The packages also allows passing `@icon` as an object (Icon Definition), as shown below:
 If you use this approach consistently, you only need to configure `config.autoAddCss = false;` inside `font-awesome.ts`.
 This use case is especially useful for people using template tag components (.gjs/.gts). You can find more about template tags [here](https://guides.emberjs.com/release/components/template-tag-format/)
 
-```ts
+```gts
 // app/components/some-component.gts
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faSquare } from '@fortawesome/free-solid-svg-icons';
 
 <template>
   <FaIcon @icon={{faSquare}} />
 </template>
 ```
+
+In this case you don't need to pass `@prefix` because the prefix is automatically defined within the imported object.
+
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -108,14 +108,14 @@ Create `app/font-awesome.js/ts` with following content
 
 ```ts
 // app/font-awesome.ts
-import { library, config as faConfig } from '@fortawesome/fontawesome-svg-core';
+import { library, config } from '@fortawesome/fontawesome-svg-core';
 import '@fortawesome/fontawesome-svg-core/styles.css'; // This adds the basic icon styles into your app
 import * as freeSolidIcons from '@fortawesome/free-solid-svg-icons';
 
 // Disable auto CSS import into head. It solved the side effect for jumping icon size.
 // This is required to for Fastboot apps, otherwise build fails
 // It's the recommended way for setup Font Awesome in your app
-faConfig.autoAddCss = false;
+config.autoAddCss = false;
 
 // option to import all icons from solid pack.
 // If you want to import only a subset of icons from pack, see section "Subsetting icons"
@@ -278,6 +278,19 @@ If you want to use an icon from any style other than the default, use `prefix=`.
 
 ```hbs
 <FaIcon @icon="square" @prefix="far" />
+```
+
+Note: The packages also allows passing `@icon` as an object, as shown below:
+If you use this approach consistently, you only need to configure `config.autoAddCss = false;` inside `font-awesome.ts`.
+This use case is especially useful for people using template tag components (.gjs/.gts). You can find more about template tags [here](https://guides.emberjs.com/release/components/template-tag-format/)
+
+```ts
+// app/components/some-component.gts
+import { faSquare } from '@fortawesome/free-solid-svg-icons';
+
+<template>
+  <FaIcon @icon={{faSquare}} />
+</template>
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ import { config } from '@fortawesome/fontawesome-svg-core';
 import '@fortawesome/fontawesome-svg-core/styles.css'; // This adds the basic icon styles into your app
 
 // Disable auto CSS import into head. It solved the side effect for jumping icon size.
-// This is required to for Fastboot apps, otherwise build fails
+// This is required for Fastboot apps, otherwise build fails
 // It's the recommended way for setup Font Awesome in your app
 config.autoAddCss = false;
 ```
@@ -143,7 +143,7 @@ loadInitializers(App, config.modulePrefix);
 
 In your template, you can use icons like this:
 
-```gts
+```ts
 // app/components/some-component.gts
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faSquare } from '@fortawesome/free-solid-svg-icons';
@@ -154,7 +154,7 @@ import { faSquare } from '@fortawesome/free-solid-svg-icons';
 ```
 
 With this approach, you no longer need to pass `@prefix` and the `defaultPrefix` configuration in `environment.js` will be ignored.
-However, when using this setup, you must always pass the icon definition instead of a string. Otherwise, the icon will not render, and a warning will appear in the developer console.
+However, with this setup, you must always pass the icon definition instead of a string; otherwise, the icon will not render, and a warning will appear in the developer console.
 
 Note:
 This setup also works with `.hbs` files, but it is more complex to use.
@@ -171,7 +171,7 @@ import '@fortawesome/fontawesome-svg-core/styles.css'; // This adds the basic ic
 import * as freeSolidIcons from '@fortawesome/free-solid-svg-icons';
 
 // Disable auto CSS import into head. It solved the side effect for jumping icon size.
-// This is required to for Fastboot apps, otherwise build fails
+// This is required for Fastboot apps, otherwise build fails
 // It's the recommended way for setup Font Awesome in your app
 config.autoAddCss = false;
 
@@ -343,7 +343,7 @@ The packages also allows passing `@icon` as an object (Icon Definition), as show
 If you use this approach consistently, you only need to configure `config.autoAddCss = false;` inside `font-awesome.ts`.
 This use case is especially useful for people using template tag components (.gjs/.gts). You can find more about template tags [here](https://guides.emberjs.com/release/components/template-tag-format/)
 
-```gts
+```ts
 // app/components/some-component.gts
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faSquare } from '@fortawesome/free-solid-svg-icons';

--- a/README.md
+++ b/README.md
@@ -102,29 +102,35 @@ or with Yarn
 yarn add --dev @fortawesome/free-solid-svg-icons
 ```
 
-After installation you need to setup Font Awesome in your `app.js/ts` by adding the setup section part like bellow.
-After these changes your app file should look something like:
+After installation you need to setup the package in your app by adding the section parts like bellow.
+
+Create `app/font-awesome.js/ts` with following content
 
 ```ts
-import Application from '@ember/application';
-import Resolver from 'ember-resolver';
-import loadInitializers from 'ember-load-initializers';
-import config from 'app-name/config/environment';
-
-// Start - Font Awesome setup
+// app/font-awesome.ts
 import { library, config as faConfig } from '@fortawesome/fontawesome-svg-core';
 import '@fortawesome/fontawesome-svg-core/styles.css'; // This adds the basic icon styles into your app
 import * as freeSolidIcons from '@fortawesome/free-solid-svg-icons';
 
 // Disable auto CSS import into head. It solved the side effect for jumping icon size.
-// This is required to for Fastboot apps, otherwise build failes
+// This is required to for Fastboot apps, otherwise build fails
 // It's the recommended way for setup Font Awesome in your app
 faConfig.autoAddCss = false;
 
 // option to import all icons from solid pack.
 // If you want to import only a subset of icons from pack, see section "Subsetting icons"
 library.add(freeSolidIcons['fas']);
-// End - Font Awesome setup
+```
+
+Import the created `font-awesome.js/ts` file in `app.js/ts`.
+
+```ts
+// app/app.ts
+import Application from '@ember/application';
+import Resolver from 'ember-resolver';
+import loadInitializers from 'ember-load-initializers';
+import config from 'app-name/config/environment';
+import './font-awesome'; // Add this import statement for Font Awesome setup
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -30,7 +30,7 @@ module.exports = function () {
 };
 ```
 
-The icon import must be added now into the file `app/font-awesome.js/ts` like in this example:
+The icon imports must now be added to the `app/font-awesome.js/ts` file, as shown in this example:
 
 ```ts
 // app/font-awesome.ts
@@ -72,14 +72,14 @@ To do so, add the following lines to your `app.js/ts`:
 
 ```ts
 // app/font-awesome.ts
-import { config as faConfig } from '@fortawesome/fontawesome-svg-core';
+import { config } from '@fortawesome/fontawesome-svg-core';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 
-faConfig.autoAddCss = false;
+config.autoAddCss = false;
 ```
 
-You might wonder why we manually import the CSS and disable `faConfig.autoAddCss`.
-1. The default value (`faConfig.autoAddCss = true`) does not work properly with [Fastboot](https://github.com/ember-fastboot/ember-cli-fastboot).
+You might wonder why we manually import the CSS and disable `config.autoAddCss`.
+1. The default value (`config.autoAddCss = true`) does not work properly with [Fastboot](https://github.com/ember-fastboot/ember-cli-fastboot).
 2. When using `autoAddCss`, styles are loaded too late, causing icons to appear incorrectly at app startup.
 
 
@@ -88,6 +88,8 @@ In previous versions (<3.0), this configuration was handled automatically within
 
 After making these changes, your `app/font-awesome.js/ts` and `app/app.js/ts` file should match the structure described in the [installation guide](https://github.com/FortAwesome/ember-fontawesome/tree/3.x?tab=readme-ov-file#installation)
 
+
+Note: If you passed the icon definition (object) to `@icon`, the only change you may need to make is importing the styles. Everything else should work as before.
 
 ### Glint support
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -85,9 +85,9 @@ You might wonder why we manually import the CSS and disable `config.autoAddCss`.
 
 In previous versions (<3.0), this configuration was handled automatically within the addon. To avoid unwanted behavior, we recommend adding these lines explicitly to your project.
 
+After making these changes, your `app/font-awesome.js/ts` and `app/app.js/ts` file should match the structure described in the [installation guide](https://github.com/FortAwesome/ember-fontawesome/tree/3.x?tab=readme-ov-file#installation).
 
-After making these changes, your `app/font-awesome.js/ts` and `app/app.js/ts` file should match the structure described in the [installation guide](https://github.com/FortAwesome/ember-fontawesome/tree/3.x?tab=readme-ov-file#installation)
-
+If you are using `.gjs / .gts`, check out the [installation guide](https://github.com/FortAwesome/ember-fontawesome/tree/3.x?tab=readme-ov-file#installation) for an alternative setup option.
 
 Note: If you passed the icon definition (object) to `@icon`, the only change you may need to make is importing the styles. Everything else should work as before.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -30,10 +30,10 @@ module.exports = function () {
 };
 ```
 
-Now, you must import each icon directly in `app.js/ts`, as shown in this example:
+The icon import must be added now into the file `app/font-awesome.js/ts` like in this example:
 
 ```ts
-// app.ts
+// app/font-awesome.ts
 import { library } from '@fortawesome/fontawesome-svg-core';
 import {
   faCoffee,
@@ -53,9 +53,15 @@ library.add(freeBrandSvgIcons['fab']); // option to import all icons of fab
 library.add(freeRegularSvgIcons['far']); // option to import all icons of far
 ```
 
+In your `app.js/ts` file you need to add this import
+
+```ts
+// app/app.ts
+import './font-awesome';
+```
+
 Switching to this approach reduces maintenance costs for the addon while allowing you to use any newly released Font Awesome icon package without requiring updates to this addon.
 Additionally, you no longer need to restart your Ember when adding new icons.
-
 
 ### Style
 
@@ -65,7 +71,7 @@ With the v2 addon format, this behavior has been removed, meaning you must now m
 To do so, add the following lines to your `app.js/ts`:
 
 ```ts
-// app.ts
+// app/font-awesome.ts
 import { config as faConfig } from '@fortawesome/fontawesome-svg-core';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 
@@ -80,7 +86,7 @@ You might wonder why we manually import the CSS and disable `faConfig.autoAddCss
 In previous versions (<3.0), this configuration was handled automatically within the addon. To avoid unwanted behavior, we recommend adding these lines explicitly to your project.
 
 
-After making these changes, your `app.js/ts` file should match the structure described in the [installation guide](https://github.com/FortAwesome/ember-fontawesome/tree/3.x?tab=readme-ov-file#installation)
+After making these changes, your `app/font-awesome.js/ts` and `app/app.js/ts` file should match the structure described in the [installation guide](https://github.com/FortAwesome/ember-fontawesome/tree/3.x?tab=readme-ov-file#installation)
 
 
 ### Glint support

--- a/ember-fontawesome/src/components/fa-icon.gts
+++ b/ember-fontawesome/src/components/fa-icon.gts
@@ -6,6 +6,7 @@ import {
   type AbstractElement,
   type FaSymbol,
   type FlipProp,
+  type IconDefinition,
   type IconLookup,
   type IconName,
   type IconParams,
@@ -34,7 +35,7 @@ function objectWithKey(
 interface FaIconSignature {
   Element: SVGElement;
   Args: {
-    icon: IconName | IconLookup;
+    icon: IconName | IconLookup | IconDefinition;
     prefix?: IconPrefix;
     flip?: FlipProp;
     spin?: boolean;
@@ -48,7 +49,7 @@ interface FaIconSignature {
     transform?: Transform | string;
     symbol?: FaSymbol;
     title?: string;
-    mask?: IconName | IconLookup;
+    mask?: IconName | IconLookup | IconDefinition;
   };
 }
 
@@ -98,7 +99,7 @@ export default class FaIconComponent extends Component<FaIconSignature> {
   }
 
   get abstractIcon(): AbstractElement | null {
-    const iconLookup = this.normalizeIconArgs(this.args.prefix, this.args.icon);
+    const iconLookup = this.normalizeIconArgs(this.args.icon, this.args.prefix);
     if (!iconLookup) {
       console.warn(
         'Could not find icon: Icon argument was passed empty, undefined or null!',
@@ -114,7 +115,7 @@ export default class FaIconComponent extends Component<FaIconSignature> {
     );
     const mask = objectWithKey(
       'mask',
-      this.normalizeIconArgs(null, this.args.mask),
+      this.args.mask ? this.normalizeIconArgs(this.args.mask) : null,
     );
     const symbol = this.args.symbol ?? false;
     const title = this.args.title ? `${this.args.title}` : null;
@@ -127,7 +128,7 @@ export default class FaIconComponent extends Component<FaIconSignature> {
     const renderedIcon = icon(iconLookup, o);
     if (!renderedIcon) {
       console.warn(
-        `Could not find icon: iconName=${iconLookup.iconName}, prefix=${iconLookup.prefix}. You may need to add it to your app.js/ts.`,
+        `Could not find icon: iconName=${iconLookup.iconName}, prefix=${iconLookup.prefix}. You may need to add it to your font-awesome.js/ts.`,
       );
       return null;
     }
@@ -172,9 +173,9 @@ export default class FaIconComponent extends Component<FaIconSignature> {
     return (this.abstractIcon?.attributes?.viewBox as string) ?? '0 0 448 512';
   }
 
-  normalizeIconArgs(
-    prefix: IconPrefix | null | undefined,
-    icon: IconName | IconLookup | undefined,
+  private normalizeIconArgs(
+    icon: IconName | IconLookup | IconDefinition,
+    prefix?: IconPrefix,
   ): IconLookup | null {
     // @ts-expect-error Property 'resolveRegistration' does not exist on type 'Owner'.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call

--- a/test-app/app/app.ts
+++ b/test-app/app/app.ts
@@ -2,52 +2,7 @@ import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'test-app/config/environment';
-import { library, config as faConfig } from '@fortawesome/fontawesome-svg-core';
-import '@fortawesome/fontawesome-svg-core/styles.css';
-import {
-  faCoffee,
-  faMagic,
-  faCircle,
-  faCheck,
-  faSquare,
-  faHome,
-  faInfo,
-  faBook,
-  faPencilAlt,
-  faCog,
-  faSpinner,
-  faCheckSquare,
-  faFax,
-  faSync,
-  faStopwatch20,
-  faTrashAlt,
-} from '@fortawesome/free-solid-svg-icons';
-import * as freeRegularSvgIcons from '@fortawesome/free-regular-svg-icons';
-import * as freeBrandSvgIcons from '@fortawesome/free-brands-svg-icons';
-
-library.add(
-  faCoffee,
-  faMagic,
-  faCircle,
-  faCheck,
-  faSquare,
-  faHome,
-  faInfo,
-  faBook,
-  faPencilAlt,
-  faCog,
-  faSpinner,
-  faCheckSquare,
-  faFax,
-  faSync,
-  faStopwatch20,
-  faTrashAlt,
-);
-
-library.add(freeBrandSvgIcons['fab']);
-library.add(freeRegularSvgIcons['far']);
-
-faConfig.autoAddCss = false;
+import './font-awesome';
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;

--- a/test-app/app/font-awesome.ts
+++ b/test-app/app/font-awesome.ts
@@ -1,0 +1,46 @@
+import { library, config } from '@fortawesome/fontawesome-svg-core';
+import '@fortawesome/fontawesome-svg-core/styles.css';
+import {
+  faCoffee,
+  faMagic,
+  faCircle,
+  faCheck,
+  faSquare,
+  faHome,
+  faInfo,
+  faBook,
+  faPencilAlt,
+  faCog,
+  faSpinner,
+  faCheckSquare,
+  faFax,
+  faSync,
+  faStopwatch20,
+  faTrashAlt,
+} from '@fortawesome/free-solid-svg-icons';
+import * as freeRegularSvgIcons from '@fortawesome/free-regular-svg-icons';
+import * as freeBrandSvgIcons from '@fortawesome/free-brands-svg-icons';
+
+config.autoAddCss = false;
+
+library.add(
+  faCoffee,
+  faMagic,
+  faCircle,
+  faCheck,
+  faSquare,
+  faHome,
+  faInfo,
+  faBook,
+  faPencilAlt,
+  faCog,
+  faSpinner,
+  faCheckSquare,
+  faFax,
+  faSync,
+  faStopwatch20,
+  faTrashAlt,
+);
+
+library.add(freeBrandSvgIcons['fab']);
+library.add(freeRegularSvgIcons['far']);


### PR DESCRIPTION
During some tests inside my app, i think its better to hold the `app.ts` file cleaner and moving setups to an extra file like we did before.

In additional we need to allow passing `IconDefinition` as `@icon` to component.
We have already a use case for that inside test-app and maybe peoples were already using it.
Passing `IconDefinition` is very interesting, when consumer apps are using template-tag (strict mode) in ember (which is part of polaris edition and can be used already), because this make at the end the `font-awesome.ts` nearly unnecessary (just the setup for `faConfig.autoAddCss = false;` is needed.
Its more a choise for consumer apps, if they want register icons and consume with string or importing icon directly at each point.

Changes in this PR:
- Improve typing inside icon component
- allow passing `IconDefinition`
- Update docs setup and apply changes to test-app
- Add note for passing `IconDefinition`